### PR TITLE
Release 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <buildVersion>1.0.1-SNAPSHOT</buildVersion>
+        <buildVersion>1.0.2-SNAPSHOT</buildVersion>
     </properties>
 
     <groupId>org.javawebstack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.29</version>
+            <version>1.30</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>bson</artifactId>
-            <version>4.4.1</version>
+            <version>4.6.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
@@ -1,6 +1,7 @@
 package org.javawebstack.abstractdata;
 
 import org.javawebstack.abstractdata.collector.AbstractArrayCollector;
+import org.javawebstack.abstractdata.exception.AbstractCoercingException;
 
 import java.util.*;
 import java.util.function.Function;
@@ -15,109 +16,118 @@ public class AbstractArray implements AbstractElement, Iterable<AbstractElement>
         return true;
     }
 
-    public AbstractArray array() {
+    public AbstractArray array(boolean strict) throws AbstractCoercingException {
         return this;
     }
 
-    public AbstractObject object(String key) {
+    public AbstractObject object(boolean strict) throws AbstractCoercingException {
+        if(strict)
+            throw new AbstractCoercingException(Type.OBJECT, Type.ARRAY);
+        AbstractObject object = new AbstractObject();
+        for(int i=0; i< elements.size(); i++)
+            object.set(String.valueOf(i), elements.get(i));
+        return object;
+    }
+
+    public AbstractObject object(String key) throws AbstractCoercingException {
         return query(key).object();
     }
 
-    public AbstractArray array(String key) {
+    public AbstractArray array(String key) throws AbstractCoercingException {
         return query(key).array();
     }
 
-    public AbstractPrimitive primitive(String key) {
+    public AbstractPrimitive primitive(String key) throws AbstractCoercingException {
         return query(key).primitive();
     }
 
-    public String string(String key) {
+    public String string(String key) throws AbstractCoercingException {
         return query(key).string();
     }
 
-    public Boolean bool(String key) {
+    public Boolean bool(String key) throws AbstractCoercingException {
         return query(key).bool();
     }
 
-    public Number number(String key) {
+    public Number number(String key) throws AbstractCoercingException {
         return query(key).number();
     }
 
-    public AbstractObject object(String key, AbstractObject orElse) {
+    public AbstractObject object(String key, AbstractObject orElse) throws AbstractCoercingException {
         return query(key, orElse).object();
     }
 
-    public AbstractArray array(String key, AbstractArray orElse) {
+    public AbstractArray array(String key, AbstractArray orElse) throws AbstractCoercingException {
         return query(key, orElse).array();
     }
 
-    public AbstractPrimitive primitive(String key, AbstractPrimitive orElse) {
+    public AbstractPrimitive primitive(String key, AbstractPrimitive orElse) throws AbstractCoercingException {
         return query(key, orElse).primitive();
     }
 
-    public String string(String key, String orElse) {
+    public String string(String key, String orElse) throws AbstractCoercingException {
         return query(key, new AbstractPrimitive(orElse)).string();
     }
 
-    public Boolean bool(String key, Boolean orElse) {
+    public Boolean bool(String key, Boolean orElse) throws AbstractCoercingException {
         return query(key, new AbstractPrimitive(orElse)).bool();
     }
 
-    public Number number(String key, Number orElse) {
+    public Number number(String key, Number orElse) throws AbstractCoercingException {
         return query(key, new AbstractPrimitive(orElse)).number();
     }
 
-    public AbstractObject object(int index) {
+    public AbstractObject object(int index) throws AbstractCoercingException {
         return get(index).object();
     }
 
-    public AbstractArray array(int index) {
+    public AbstractArray array(int index) throws AbstractCoercingException {
         return get(index).array();
     }
 
-    public AbstractPrimitive primitive(int index) {
+    public AbstractPrimitive primitive(int index) throws AbstractCoercingException {
         return get(index).primitive();
     }
 
-    public String string(int index) {
+    public String string(int index) throws AbstractCoercingException {
         return get(index).string();
     }
 
-    public Boolean bool(int index) {
+    public Boolean bool(int index) throws AbstractCoercingException {
         return get(index).bool();
     }
 
-    public Number number(int index) {
+    public Number number(int index) throws AbstractCoercingException {
         return get(index).number();
     }
 
-    public AbstractObject object(int index, AbstractObject orElse) {
+    public AbstractObject object(int index, AbstractObject orElse) throws AbstractCoercingException {
         return get(index, orElse).object();
     }
 
-    public AbstractArray array(int index, AbstractArray orElse) {
+    public AbstractArray array(int index, AbstractArray orElse) throws AbstractCoercingException {
         return get(index, orElse).array();
     }
 
-    public AbstractPrimitive primitive(int index, AbstractPrimitive orElse) {
+    public AbstractPrimitive primitive(int index, AbstractPrimitive orElse) throws AbstractCoercingException {
         return get(index, orElse).primitive();
     }
 
-    public String string(int index, String orElse) {
+    public String string(int index, String orElse) throws AbstractCoercingException {
         return get(index, new AbstractPrimitive(orElse)).string();
     }
 
-    public Boolean bool(int index, Boolean orElse) {
+    public Boolean bool(int index, Boolean orElse) throws AbstractCoercingException {
         return get(index, new AbstractPrimitive(orElse)).bool();
     }
 
-    public Number number(int index, Number orElse) {
+    public Number number(int index, Number orElse) throws AbstractCoercingException {
         return get(index, new AbstractPrimitive(orElse)).number();
     }
 
     public AbstractArray add(AbstractElement element) {
         if (element == null)
-            element = AbstractNull.INSTANCE;
+            element = AbstractNull.VALUE;
         elements.add(element);
         return this;
     }
@@ -141,7 +151,7 @@ public class AbstractArray implements AbstractElement, Iterable<AbstractElement>
     }
 
     public AbstractArray addNull() {
-        return add(AbstractNull.INSTANCE);
+        return add(AbstractNull.VALUE);
     }
 
     public AbstractArray add(Number value) {
@@ -163,7 +173,7 @@ public class AbstractArray implements AbstractElement, Iterable<AbstractElement>
     }
 
     public AbstractArray setNull(int i) {
-        return set(i, AbstractNull.INSTANCE);
+        return set(i, AbstractNull.VALUE);
     }
 
     public AbstractArray set(int i, AbstractElement element) {

--- a/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
@@ -274,6 +274,28 @@ public class AbstractArray implements AbstractElement, Iterable<AbstractElement>
         return list;
     }
 
+    public List<String> toStringList() {
+        return toStringList(false);
+    }
+
+    public List<String> toStringList(boolean strict) {
+        List<String> list = new ArrayList<>();
+        for(AbstractElement e : elements)
+            list.add(e.string(strict));
+        return list;
+    }
+
+    public List<AbstractObject> toObjectList() {
+        return toObjectList(false);
+    }
+
+    public List<AbstractObject> toObjectList(boolean strict) {
+        List<AbstractObject> list = new ArrayList<>();
+        for(AbstractElement e : elements)
+            list.add(e.object(strict));
+        return list;
+    }
+
     public static AbstractArray fromArray(Object[] objects) {
         return new AbstractArray(objects);
     }

--- a/src/main/java/org/javawebstack/abstractdata/AbstractElement.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractElement.java
@@ -3,6 +3,7 @@ package org.javawebstack.abstractdata;
 import org.bson.BsonValue;
 import org.javawebstack.abstractdata.bson.BsonConverter;
 import org.javawebstack.abstractdata.bson.BsonTypeAdapter;
+import org.javawebstack.abstractdata.exception.AbstractCoercingException;
 import org.javawebstack.abstractdata.json.JsonDumper;
 import org.javawebstack.abstractdata.json.JsonParser;
 import org.javawebstack.abstractdata.util.QueryString;
@@ -46,34 +47,48 @@ public interface AbstractElement {
         return false;
     }
 
-    default AbstractPrimitive primitive() {
-        return null;
+    default AbstractPrimitive primitive() throws AbstractCoercingException {
+        throw new AbstractCoercingException("PRIMITIVE", getType());
     }
 
-    default AbstractArray array() {
-        return null;
+    default AbstractArray array() throws AbstractCoercingException {
+        return array(false);
     }
 
-    default AbstractObject object() {
-        return null;
+    default AbstractObject object() throws AbstractCoercingException {
+        return object(false);
     }
 
-    default String string() {
-        if (!isString())
-            return null;
-        return primitive().string();
+    default AbstractArray array(boolean strict) throws AbstractCoercingException {
+        throw new AbstractCoercingException("ARRAY", getType());
     }
 
-    default Boolean bool() {
-        if (!isBoolean())
-            return null;
-        return primitive().bool();
+    default AbstractObject object(boolean strict) throws AbstractCoercingException {
+        throw new AbstractCoercingException("OBJECT", getType());
     }
 
-    default Number number() {
-        if (!isNumber())
-            return null;
-        return primitive().number();
+    default String string() throws AbstractCoercingException {
+        return string(false);
+    }
+
+    default Boolean bool() throws AbstractCoercingException {
+        return bool(false);
+    }
+
+    default Number number() throws AbstractCoercingException {
+        return number(false);
+    }
+
+    default String string(boolean strict) throws AbstractCoercingException {
+        return primitive().string(strict);
+    }
+
+    default Boolean bool(boolean strict) throws AbstractCoercingException {
+        return primitive().bool(strict);
+    }
+
+    default Number number(boolean strict) throws AbstractCoercingException {
+        return primitive().number(strict);
     }
 
     default BsonValue toBson() {
@@ -131,7 +146,7 @@ public interface AbstractElement {
 
     static AbstractElement fromAbstractObject(Object object) {
         if (object == null)
-            return AbstractNull.INSTANCE;
+            return AbstractNull.VALUE;
         if (object instanceof List) {
             List<Object> list = (List<Object>) object;
             AbstractArray array = new AbstractArray();
@@ -150,7 +165,7 @@ public interface AbstractElement {
             return new AbstractPrimitive((String) object);
         if (object instanceof Boolean)
             return new AbstractPrimitive((Boolean) object);
-        return AbstractNull.INSTANCE;
+        return AbstractNull.VALUE;
     }
 
     default QueryString toFormData() {

--- a/src/main/java/org/javawebstack/abstractdata/AbstractNull.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractNull.java
@@ -1,17 +1,39 @@
 package org.javawebstack.abstractdata;
 
+import org.javawebstack.abstractdata.exception.AbstractCoercingException;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public class AbstractNull implements AbstractElement {
 
-    public static final AbstractNull INSTANCE = new AbstractNull();
+    public static final AbstractNull VALUE = new AbstractNull();
+    @Deprecated
+    public static final AbstractNull INSTANCE = VALUE;
 
     private AbstractNull() {
     }
 
     public boolean isNull() {
         return true;
+    }
+
+    public String string(boolean strict) throws AbstractCoercingException {
+        if(strict)
+            throw new AbstractCoercingException(Type.STRING, Type.NULL);
+        return null;
+    }
+
+    public Boolean bool(boolean strict) throws AbstractCoercingException {
+        if(strict)
+            throw new AbstractCoercingException(Type.STRING, Type.NULL);
+        return null;
+    }
+
+    public Number number(boolean strict) throws AbstractCoercingException {
+        if(strict)
+            throw new AbstractCoercingException(Type.STRING, Type.NULL);
+        return null;
     }
 
     public Object toObject() {

--- a/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
@@ -98,6 +98,30 @@ public class AbstractObject implements AbstractElement {
         return entries.containsKey(key);
     }
 
+    public boolean hasString(String key) {
+        return has(key) && get(key).isString();
+    }
+
+    public boolean hasNumber(String key) {
+        return has(key) && get(key).isNumber();
+    }
+
+    public boolean hasBoolean(String key) {
+        return has(key) && get(key).isBoolean();
+    }
+
+    public boolean hasPrimitive(String key) {
+        return has(key) && get(key).isPrimitive();
+    }
+
+    public boolean hasObject(String key) {
+        return has(key) && get(key).isObject();
+    }
+
+    public boolean hasArray(String key) {
+        return has(key) && get(key).isArray();
+    }
+
     public int size() {
         return entries.size();
     }
@@ -113,7 +137,7 @@ public class AbstractObject implements AbstractElement {
     }
 
     public AbstractObject object(String key) {
-        return query(key).object();
+        return query(key, AbstractNull.INSTANCE).object();
     }
 
     public AbstractObject object(String key, AbstractObject orElse) {
@@ -121,7 +145,7 @@ public class AbstractObject implements AbstractElement {
     }
 
     public AbstractArray array(String key) {
-        return query(key).array();
+        return query(key, AbstractNull.INSTANCE).array();
     }
 
     public AbstractArray array(String key, AbstractArray orElse) {
@@ -129,7 +153,7 @@ public class AbstractObject implements AbstractElement {
     }
 
     public AbstractPrimitive primitive(String key) {
-        return query(key).primitive();
+        return query(key, AbstractNull.INSTANCE).primitive();
     }
 
     public AbstractPrimitive primitive(String key, AbstractPrimitive orElse) {
@@ -137,7 +161,7 @@ public class AbstractObject implements AbstractElement {
     }
 
     public String string(String key) {
-        return query(key).string();
+        return query(key, AbstractNull.INSTANCE).string();
     }
 
     public String string(String key, String orElse) {
@@ -145,7 +169,7 @@ public class AbstractObject implements AbstractElement {
     }
 
     public Boolean bool(String key) {
-        return query(key).bool();
+        return query(key, AbstractNull.INSTANCE).bool();
     }
 
     public Boolean bool(String key, Boolean orElse) {
@@ -153,7 +177,7 @@ public class AbstractObject implements AbstractElement {
     }
 
     public Number number(String key) {
-        return query(key).number();
+        return query(key, AbstractNull.INSTANCE).number();
     }
 
     public Number number(String key, Number orElse) {

--- a/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
@@ -1,6 +1,7 @@
 package org.javawebstack.abstractdata;
 
 import org.javawebstack.abstractdata.collector.AbstractObjectCollector;
+import org.javawebstack.abstractdata.exception.AbstractCoercingException;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -21,13 +22,13 @@ public class AbstractObject implements AbstractElement {
     }
 
     public AbstractObject setNull(String key) {
-        set(key, AbstractNull.INSTANCE);
+        set(key, AbstractNull.VALUE);
         return this;
     }
 
     public AbstractObject set(String key, AbstractElement value) {
         if (value == null)
-            value = AbstractNull.INSTANCE;
+            value = AbstractNull.VALUE;
         entries.put(key, value);
         return this;
     }
@@ -126,61 +127,63 @@ public class AbstractObject implements AbstractElement {
         return entries.size();
     }
 
-    public AbstractArray array() {
+    public AbstractArray array(boolean strict) throws AbstractCoercingException {
+        if(strict)
+            throw new AbstractCoercingException(Type.ARRAY, Type.OBJECT);
         AbstractArray array = new AbstractArray();
         for (int i = 0; i < size(); i++) {
             if (!has(String.valueOf(i)))
-                return null;
+                throw new AbstractCoercingException(Type.ARRAY, this);
             array.add(get(String.valueOf(i)));
         }
         return array;
     }
 
-    public AbstractObject object(String key) {
-        return query(key, AbstractNull.INSTANCE).object();
+    public AbstractObject object(String key) throws AbstractCoercingException {
+        return query(key, AbstractNull.VALUE).object();
     }
 
-    public AbstractObject object(String key, AbstractObject orElse) {
+    public AbstractObject object(String key, AbstractObject orElse) throws AbstractCoercingException {
         return query(key, orElse).object();
     }
 
-    public AbstractArray array(String key) {
-        return query(key, AbstractNull.INSTANCE).array();
+    public AbstractArray array(String key) throws AbstractCoercingException {
+        return query(key, AbstractNull.VALUE).array();
     }
 
-    public AbstractArray array(String key, AbstractArray orElse) {
+    public AbstractArray array(String key, AbstractArray orElse) throws AbstractCoercingException {
         return query(key, orElse).array();
     }
 
-    public AbstractPrimitive primitive(String key) {
-        return query(key, AbstractNull.INSTANCE).primitive();
+    public AbstractPrimitive primitive(String key) throws AbstractCoercingException {
+        return query(key, AbstractNull.VALUE).primitive();
     }
 
-    public AbstractPrimitive primitive(String key, AbstractPrimitive orElse) {
+    public AbstractPrimitive primitive(String key, AbstractPrimitive orElse) throws AbstractCoercingException {
         return query(key, orElse).primitive();
     }
 
-    public String string(String key) {
-        return query(key, AbstractNull.INSTANCE).string();
+    public String string(String key) throws AbstractCoercingException {
+        return query(key, AbstractNull.VALUE).string();
     }
 
-    public String string(String key, String orElse) {
+    public String string(String key, String orElse) throws AbstractCoercingException {
         return query(key, new AbstractPrimitive(orElse)).string();
     }
 
-    public Boolean bool(String key) {
-        return query(key, AbstractNull.INSTANCE).bool();
+    public Boolean bool(String key) throws AbstractCoercingException {
+        return query(key, AbstractNull.VALUE).bool();
     }
 
-    public Boolean bool(String key, Boolean orElse) {
+    public Boolean bool(String key, Boolean orElse) throws AbstractCoercingException {
         return query(key, new AbstractPrimitive(orElse)).bool();
     }
 
-    public Number number(String key) {
-        return query(key, AbstractNull.INSTANCE).number();
+    public Number number(String key) throws AbstractCoercingException {
+        return query(key, AbstractNull.VALUE).number();
     }
 
-    public Number number(String key, Number orElse) {
+    public Number number(String key, Number orElse) throws AbstractCoercingException {
         return query(key, new AbstractPrimitive(orElse)).number();
     }
 

--- a/src/main/java/org/javawebstack/abstractdata/bson/BsonConverter.java
+++ b/src/main/java/org/javawebstack/abstractdata/bson/BsonConverter.java
@@ -35,7 +35,7 @@ public class BsonConverter {
     public AbstractElement toAbstract(BsonValue value) {
         switch (value.getBsonType()) {
             case NULL:
-                return AbstractNull.INSTANCE;
+                return AbstractNull.VALUE;
             case STRING:
                 return new AbstractPrimitive(value.asString().getValue());
             case BOOLEAN:

--- a/src/main/java/org/javawebstack/abstractdata/bson/BsonConverter.java
+++ b/src/main/java/org/javawebstack/abstractdata/bson/BsonConverter.java
@@ -5,7 +5,6 @@ import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.javawebstack.abstractdata.*;
 
-import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/src/main/java/org/javawebstack/abstractdata/bson/BsonConverter.java
+++ b/src/main/java/org/javawebstack/abstractdata/bson/BsonConverter.java
@@ -1,14 +1,15 @@
 package org.javawebstack.abstractdata.bson;
 
 import org.bson.*;
-import org.bson.internal.Base64;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.javawebstack.abstractdata.*;
 
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 
 public class BsonConverter {
@@ -77,8 +78,9 @@ public class BsonConverter {
                         .set("i", Integer.toUnsignedLong(value.asTimestamp().getInc()))
                 );
             case BINARY:
+                String base64 = new String(Base64.getEncoder().encode(value.asBinary().getData()));
                 return new AbstractObject().set("$binary", new AbstractObject()
-                        .set("base64", Base64.encode(value.asBinary().getData()))
+                        .set("base64", base64)
                         .set("subType", String.format("%02x", value.asBinary().getType()))
                 );
             case ARRAY: {
@@ -155,7 +157,7 @@ public class BsonConverter {
         if(o.size() == 1 && o.has("$binary") && o.get("$binary").isObject()) {
             AbstractObject bin = o.object("$binary");
             if(bin.has("base64") && bin.has("subType") && bin.get("base64").isString() && bin.get("subType").isString()) {
-                byte[] data = Base64.decode(bin.string("base64"));
+                byte[] data = Base64.getDecoder().decode(bin.string("base64"));
                 byte type = (byte) Integer.parseInt(bin.string("subType"), 16);
                 return new BsonBinary(type, data);
             }

--- a/src/main/java/org/javawebstack/abstractdata/exception/AbstractCoercingException.java
+++ b/src/main/java/org/javawebstack/abstractdata/exception/AbstractCoercingException.java
@@ -1,0 +1,19 @@
+package org.javawebstack.abstractdata.exception;
+
+import org.javawebstack.abstractdata.AbstractElement;
+
+public class AbstractCoercingException extends RuntimeException {
+
+    public AbstractCoercingException(AbstractElement.Type requested, AbstractElement.Type found) {
+        this(requested.name(), found);
+    }
+
+    public AbstractCoercingException(String requested, AbstractElement.Type found) {
+        super("Type '" + found.name() + "' can not be coerced into type '" + requested + "' or strict mode prohibits type coercing");
+    }
+
+    public AbstractCoercingException(AbstractElement.Type requested, AbstractElement found) {
+        super("Value '" + found.toJsonString() + "' can not be coerced into type '" + requested.name() + "'");
+    }
+
+}

--- a/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
+++ b/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
@@ -82,7 +82,7 @@ public class JsonParser {
                 if(stack.peek() != 'l')
                     return null;
                 stack.pop();
-                return AbstractNull.INSTANCE;
+                return AbstractNull.VALUE;
             }
             case '0':
             case '1':

--- a/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
+++ b/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
@@ -114,7 +114,7 @@ public class JsonParser {
 
     private AbstractPrimitive parseNumber(Deque<Character> stack) {
         StringBuilder sb = new StringBuilder();
-        while (Character.isDigit(stack.peek()) || stack.peek() == '.' || stack.peek() == '-')
+        while (Character.isDigit(stack.peek()) || stack.peek() == '.' || stack.peek() == '-' || stack.peek() == 'E' || stack.peek() == 'e')
             sb.append(stack.pop());
         String s = sb.toString();
         if(s.contains(".")) {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
@@ -1,6 +1,8 @@
 package org.javawebstack.abstractdata.mapper;
 
 import org.javawebstack.abstractdata.*;
+import org.javawebstack.abstractdata.exception.AbstractCoercingException;
+import org.javawebstack.abstractdata.mapper.annotation.DateFormat;
 import org.javawebstack.abstractdata.mapper.exception.MapperException;
 import org.javawebstack.abstractdata.mapper.exception.MapperWrongTypeException;
 import org.javawebstack.abstractdata.util.Helpers;
@@ -9,6 +11,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Timestamp;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
@@ -54,41 +57,55 @@ public final class DefaultMappers {
 
         public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
             if(type.equals(String.class)) {
-                if(!element.isString())
+                try {
+                    return element.string(context.getMapper().isStrict());
+                } catch (AbstractCoercingException ex) {
                     throw new MapperWrongTypeException(context.getField().getName(), "string", Helpers.typeName(element));
-                return element.string();
+                }
             }
             if(type.equals(char.class) || type.equals(Character.class)) {
-                if(!element.isString())
+                if(type.isPrimitive() && element.isNull())
+                    throw new MapperWrongTypeException(context.getField().getName(), "number", "null");
+                try {
+                    String s = element.string(context.getMapper().isStrict());
+                    if(s.length() != 1)
+                        throw new MapperException("Expected string of length 1 for field " + context.getField().getName() + " but received " + s.length());
+                    return s.charAt(0);
+                } catch (AbstractCoercingException ex) {
                     throw new MapperWrongTypeException(context.getField().getName(), "string", Helpers.typeName(element));
-                String s = element.string();
-                if(s.length() != 1)
-                    throw new MapperException("Expected string of length 1 for field " + context.getField().getName() + " but received " + s.length());
-                return s.charAt(0);
+                }
             }
             if(type.equals(Boolean.class) || type.equals(boolean.class)) {
-                if(!element.isBoolean())
+                if(type.isPrimitive() && element.isNull())
+                    throw new MapperWrongTypeException(context.getField().getName(), "number", "null");
+                try {
+                    return element.bool(context.getMapper().isStrict());
+                } catch (AbstractCoercingException ex) {
                     throw new MapperWrongTypeException(context.getField().getName(), "boolean", Helpers.typeName(element));
-                return element.bool();
+                }
             }
             if(Number.class.isAssignableFrom(type) || type.isPrimitive()) {
-                if(!element.isNumber())
+                if(type.isPrimitive() && element.isNull())
+                    throw new MapperWrongTypeException(context.getField().getName(), "number", "null");
+                try {
+                    if(type.equals(int.class) || type.equals(Integer.class))
+                        return element.number(context.getMapper().isStrict()).intValue();
+                    if(type.equals(long.class) || type.equals(Long.class))
+                        return element.number(context.getMapper().isStrict()).longValue();
+                    if(type.equals(short.class) || type.equals(Short.class))
+                        return element.number(context.getMapper().isStrict()).shortValue();
+                    if(type.equals(double.class) || type.equals(Double.class))
+                        return element.number(context.getMapper().isStrict()).doubleValue();
+                    if(type.equals(float.class) || type.equals(Float.class))
+                        return element.number(context.getMapper().isStrict()).floatValue();
+                    if(type.equals(byte.class) || type.equals(Byte.class))
+                        return element.number(context.getMapper().isStrict()).byteValue();
+                    if(type.equals(Number.class))
+                        return element.number(context.getMapper().isStrict());
+                    return element.number(context.getMapper().isStrict());
+                } catch (AbstractCoercingException ex) {
                     throw new MapperWrongTypeException(context.getField().getName(), "number", Helpers.typeName(element));
-                if(type.equals(int.class) || type.equals(Integer.class))
-                    return element.number().intValue();
-                if(type.equals(long.class) || type.equals(Long.class))
-                    return element.number().longValue();
-                if(type.equals(short.class) || type.equals(Short.class))
-                    return element.number().shortValue();
-                if(type.equals(double.class) || type.equals(Double.class))
-                    return element.number().doubleValue();
-                if(type.equals(float.class) || type.equals(Float.class))
-                    return element.number().floatValue();
-                if(type.equals(byte.class) || type.equals(Byte.class))
-                    return element.number().byteValue();
-                if(type.equals(Number.class))
-                    return element.number();
-                return element.number();
+                }
             }
             throw new MapperWrongTypeException(context.getField().getName(), "primitive", Helpers.typeName(element));
         }
@@ -128,26 +145,28 @@ public final class DefaultMappers {
         }
 
         public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
-            if(!element.isArray())
-                throw new MapperWrongTypeException(context.getField().getName(), "array", Helpers.typeName(element));
             if(type.equals(List.class) || type.equals(AbstractList.class))
                 type = ArrayList.class;
             if(type.equals(Set.class))
                 type = HashSet.class;
             try {
-                Collection<Object> collection = (Collection<Object>) type.newInstance();
-                Class<?>[] genericTypes = context.getGenericTypes();
-                Class<?> elementType = genericTypes.length > 0 ? genericTypes[0] : null;
-                if(elementType == null) {
-                    for(AbstractElement e : element.array()) {
-                        elementType = Helpers.guessGeneric(e);
-                        if(elementType != null)
-                            break;
+                try {
+                    Collection<Object> collection = (Collection<Object>) type.newInstance();
+                    Class<?>[] genericTypes = context.getGenericTypes();
+                    Class<?> elementType = genericTypes.length > 0 ? genericTypes[0] : null;
+                    if(elementType == null) {
+                        for(AbstractElement e : element.array(context.getMapper().isStrict())) {
+                            elementType = Helpers.guessGeneric(e);
+                            if(elementType != null)
+                                break;
+                        }
                     }
+                    for(AbstractElement e : element.array(context.getMapper().isStrict()))
+                        collection.add(context.getMapper().map(e, elementType));
+                    return collection;
+                } catch (AbstractCoercingException ex) {
+                    throw new MapperWrongTypeException(context.getField().getName(), "array", Helpers.typeName(element));
                 }
-                for(AbstractElement e : element.array())
-                    collection.add(context.getMapper().map(e, elementType));
-                return collection;
             } catch (InstantiationException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
@@ -187,25 +206,27 @@ public final class DefaultMappers {
         }
 
         public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
-            if(!element.isObject())
-                throw new MapperWrongTypeException(context.getField().getName(), "object", Helpers.typeName(element));
             if(type.equals(Map.class) || type.equals(AbstractMap.class))
                 type = HashMap.class;
             try {
-                Map<Object, Object> map = (Map<Object, Object>) type.newInstance();
-                Class<?>[] genericTypes = context.getGenericTypes();
-                Class<?> keyType = genericTypes.length > 0 ? genericTypes[0] : String.class;
-                Class<?> valueType = genericTypes.length > 1 ? genericTypes[1] : null;
-                if(valueType == null) {
-                    for(AbstractElement e : element.object().values()) {
-                        valueType = Helpers.guessGeneric(e);
-                        if(valueType != null)
-                            break;
+                try {
+                    Map<Object, Object> map = (Map<Object, Object>) type.newInstance();
+                    Class<?>[] genericTypes = context.getGenericTypes();
+                    Class<?> keyType = genericTypes.length > 0 ? genericTypes[0] : String.class;
+                    Class<?> valueType = genericTypes.length > 1 ? genericTypes[1] : null;
+                    if(valueType == null) {
+                        for(AbstractElement e : element.object().values()) {
+                            valueType = Helpers.guessGeneric(e);
+                            if(valueType != null)
+                                break;
+                        }
                     }
+                    for(String k : element.object().keys())
+                        map.put(context.getMapper().map(new AbstractPrimitive(k), keyType), context.getMapper().map(element.object().get(k), valueType));
+                    return map;
+                } catch (AbstractCoercingException ex) {
+                    throw new MapperWrongTypeException(context.getField().getName(), "object", Helpers.typeName(element));
                 }
-                for(String k : element.object().keys())
-                    map.put(context.getMapper().map(new AbstractPrimitive(k), keyType), context.getMapper().map(element.object().get(k), valueType));
-                return map;
             } catch (InstantiationException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
@@ -235,23 +256,41 @@ public final class DefaultMappers {
         private DateMapper() {}
 
         public AbstractElement toAbstract(MapperContext context, Object value) throws MapperException {
-            if(value instanceof Date)
-                return new AbstractPrimitive(context.getMapper().getDateFormat().format((Date) value));
+            DateFormat df = context.getAnnotation(DateFormat.class);
+            if(value instanceof Date) {
+                if(df != null && df.epoch()) {
+                    long time = ((Date) value).getTime();
+                    if(!df.millis())
+                        time /= 1000;
+                    return new AbstractPrimitive(time);
+                }
+                java.text.DateFormat dateFormat = (df != null && df.value().length() > 0) ? new SimpleDateFormat(df.value()) : context.getMapper().getDateFormat();
+                return new AbstractPrimitive(dateFormat.format((Date) value));
+            }
             return null;
         }
 
         public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
-            if(!element.isString())
-                throw new MapperWrongTypeException(context.getField().getName(), "string", Helpers.typeName(element));
             try {
+                DateFormat df = context.getAnnotation(DateFormat.class);
+                java.text.DateFormat dateFormat = (df != null && df.value().length() > 0) ? new SimpleDateFormat(df.value()) : context.getMapper().getDateFormat();
+                Date date;
+                try {
+                    long time = element.number(context.getMapper().isStrict()).longValue();
+                    if(df != null && !df.millis())
+                        time *= 1000;
+                    date = new Date(time);
+                } catch (AbstractCoercingException ex) {
+                    date = dateFormat.parse(element.string(context.getMapper().isStrict()));
+                }
                 if(type.equals(Date.class))
-                    return context.getMapper().getDateFormat().parse(element.string());
+                    return date;
                 if(type.equals(java.sql.Date.class))
-                    return new java.sql.Date(context.getMapper().getDateFormat().parse(element.string()).getTime());
+                    return new java.sql.Date(date.getTime());
                 if(type.equals(Timestamp.class))
-                    return new Timestamp(context.getMapper().getDateFormat().parse(element.string()).getTime());
+                    return new Timestamp(date.getTime());
                 throw new MapperException("Unsupported date type '" + type.getName() + "'");
-            } catch (ParseException | NumberFormatException ex) {
+            } catch (ParseException | NumberFormatException | AbstractCoercingException ex) {
                 throw new MapperException("Failed to parse date '" + element.string() + "'" + (context.getField() != null ? (" for field '" + context.getField().getName() + "'") : ""));
             }
         }

--- a/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
@@ -251,8 +251,8 @@ public final class DefaultMappers {
                 if(type.equals(Timestamp.class))
                     return new Timestamp(context.getMapper().getDateFormat().parse(element.string()).getTime());
                 throw new MapperException("Unsupported date type '" + type.getName() + "'");
-            } catch (ParseException ex) {
-                throw new MapperException("Failed to parse date ''" + (context.getField() != null ? (" for field '" + context.getField().getName() + "'") : ""));
+            } catch (ParseException | NumberFormatException ex) {
+                throw new MapperException("Failed to parse date '" + element.string() + "'" + (context.getField() != null ? (" for field '" + context.getField().getName() + "'") : ""));
             }
         }
 

--- a/src/main/java/org/javawebstack/abstractdata/mapper/Mapper.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/Mapper.java
@@ -20,6 +20,7 @@ public class Mapper {
     private NamingPolicy namingPolicy = NamingPolicy.NONE;
     private boolean exposeRequired;
     private boolean omitNull = true;
+    private boolean strict = false;
     private final Map<Class<?>, MapperTypeAdapter> adapters = DefaultMappers.create();
     private final MapperContext emptyContext = new MapperContext(this, null, new HashMap<>());
 
@@ -49,7 +50,7 @@ public class Mapper {
 
     public AbstractElement map(MapperContext context, Object obj) throws MapperException {
         if(obj == null)
-            return AbstractNull.INSTANCE;
+            return AbstractNull.VALUE;
         if(obj.getClass().isArray()) {
             AbstractArray array = new AbstractArray();
             for(int i=0; i<Array.getLength(obj); i++)
@@ -59,6 +60,19 @@ public class Mapper {
         if(context.getAdapter() != null)
             return context.getAdapter().toAbstract(context, obj);
         return adapters.getOrDefault(obj.getClass(), DefaultMappers.FALLBACK).toAbstract(context, obj);
+    }
+
+    public Mapper strict() {
+        return strict(true);
+    }
+
+    public Mapper strict(boolean strict) {
+        this.strict = strict;
+        return this;
+    }
+
+    public boolean isStrict() {
+        return strict;
     }
 
     public Mapper dateFormat(String format) {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/Mapper.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/Mapper.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 public class Mapper {
 
-    private DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private String dateFormat = "yyyy-MM-dd HH:mm:ss";
     private NamingPolicy namingPolicy = NamingPolicy.NONE;
     private boolean exposeRequired;
     private boolean omitNull = true;
@@ -62,16 +62,12 @@ public class Mapper {
     }
 
     public Mapper dateFormat(String format) {
-        return dateFormat(new SimpleDateFormat(format));
-    }
-
-    public Mapper dateFormat(DateFormat dateFormat) {
-        this.dateFormat = dateFormat;
+        this.dateFormat = format;
         return this;
     }
 
     public DateFormat getDateFormat() {
-        return dateFormat;
+        return new SimpleDateFormat(dateFormat);
     }
 
     public boolean shouldOmitNull() {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/MapperTypeSpec.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/MapperTypeSpec.java
@@ -71,6 +71,7 @@ public class MapperTypeSpec {
         fieldSpecs.add(spec);
 
         spec.field = field;
+        spec.name = field.getName();
         spec.annotations = annotations;
 
         if(annotations.containsKey(MapperOptions.class)) {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/MapperTypeSpec.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/MapperTypeSpec.java
@@ -47,10 +47,13 @@ public class MapperTypeSpec {
         do {
             classes.push(current);
             current = current.getSuperclass();
-        } while (!Object.class.equals(current));
+        } while (!Object.class.equals(current)); // Collect parent classes recursively
         while (!classes.empty()) {
-            for(Field f : classes.pop().getDeclaredFields())
+            for(Field f : classes.pop().getDeclaredFields()) {
+                if(Modifier.isStatic(f.getModifiers())) // Don't include static fields
+                    continue;
                 checkoutField(f);
+            }
         }
         fieldSpecs.sort(Comparator.comparingInt(a -> a.order));
     }

--- a/src/main/java/org/javawebstack/abstractdata/mapper/MapperTypeSpec.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/MapperTypeSpec.java
@@ -71,7 +71,6 @@ public class MapperTypeSpec {
         fieldSpecs.add(spec);
 
         spec.field = field;
-        spec.name = field.getName();
         spec.annotations = annotations;
 
         if(annotations.containsKey(MapperOptions.class)) {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/annotation/DateFormat.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/annotation/DateFormat.java
@@ -1,0 +1,9 @@
+package org.javawebstack.abstractdata.mapper.annotation;
+
+public @interface DateFormat {
+
+    String value() default "";
+    boolean epoch() default false;
+    boolean millis() default false;
+
+}

--- a/src/main/java/org/javawebstack/abstractdata/mapper/naming/CamelCaseNamingPolicy.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/naming/CamelCaseNamingPolicy.java
@@ -15,7 +15,7 @@ public class CamelCaseNamingPolicy implements NamingPolicy {
     }
 
     public String fromAbstract(String source, List<String> fieldNames) {
-        return fieldNames.stream().map(this::toAbstract).filter(s -> s.equals(source)).findFirst().orElse(source);
+        return fieldNames.stream().filter(s -> toAbstract(s).equals(source)).findFirst().orElse(source);
     }
 
 }

--- a/src/main/java/org/javawebstack/abstractdata/mapper/naming/KebabCaseNamingPolicy.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/naming/KebabCaseNamingPolicy.java
@@ -11,7 +11,7 @@ public class KebabCaseNamingPolicy implements NamingPolicy {
     }
 
     public String fromAbstract(String source, List<String> fieldNames) {
-        return fieldNames.stream().map(this::toAbstract).filter(s -> s.equals(source)).findFirst().orElse(source);
+        return fieldNames.stream().filter(s -> toAbstract(s).equals(source)).findFirst().orElse(source);
     }
 
 }

--- a/src/main/java/org/javawebstack/abstractdata/mapper/naming/PascalCaseNamingPolicy.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/naming/PascalCaseNamingPolicy.java
@@ -12,7 +12,7 @@ public class PascalCaseNamingPolicy implements NamingPolicy {
     }
 
     public String fromAbstract(String source, List<String> fieldNames) {
-        return fieldNames.stream().map(this::toAbstract).filter(s -> s.equals(source)).findFirst().orElse(source);
+        return fieldNames.stream().filter(s -> toAbstract(s).equals(source)).findFirst().orElse(source);
     }
 
 }

--- a/src/main/java/org/javawebstack/abstractdata/mapper/naming/SnakeCaseNamingPolicy.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/naming/SnakeCaseNamingPolicy.java
@@ -11,7 +11,7 @@ public class SnakeCaseNamingPolicy implements NamingPolicy {
     }
 
     public String fromAbstract(String source, List<String> fieldNames) {
-        return fieldNames.stream().map(this::toAbstract).filter(s -> s.equals(source)).findFirst().orElse(source);
+        return fieldNames.stream().filter(s -> toAbstract(s).equals(source)).findFirst().orElse(source);
     }
 
 }


### PR DESCRIPTION
- Fixed several bugs introduced by the new mapper
  - SimpleDateFormat isn't thread safe, which affected date parsing in multithreaded environments
  - Added support for exponential notation of floating point numbers
  - Issue with fields that weren't explicitly named
  - Excluding static fields
- Implemented support mapping epoch timestamps on Date objects
- Implemented automatic type coercing
- Implemented a strict mode that enforces types instead of doing type coercing