### PR TITLE
Release 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ You can find the current docs on our [website](https://docs.javawebstack.org/fra
 <dependency>
     <groupId>org.javawebstack</groupId>
     <artifactId>abstract-data</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <buildVersion>1.0.3-SNAPSHOT</buildVersion>
+        <buildVersion>1.0.4-SNAPSHOT</buildVersion>
     </properties>
 
     <groupId>org.javawebstack</groupId>

--- a/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
@@ -319,6 +319,10 @@ public class AbstractArray implements AbstractElement, Iterable<AbstractElement>
         return object().toTree();
     }
 
+    public Map<String, Object> toTree(String keySeparator) {
+        return object().toTree(keySeparator);
+    }
+
     public AbstractElement clone() {
         AbstractArray array = new AbstractArray();
         forEach(e -> array.add(e.clone()));

--- a/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractArray.java
@@ -4,6 +4,7 @@ import org.javawebstack.abstractdata.collector.AbstractArrayCollector;
 import org.javawebstack.abstractdata.exception.AbstractCoercingException;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -321,6 +322,11 @@ public class AbstractArray implements AbstractElement, Iterable<AbstractElement>
 
     public Map<String, Object> toTree(String keySeparator) {
         return object().toTree(keySeparator);
+    }
+
+    public AbstractArray use(Consumer<AbstractArray> consumer) {
+        consumer.accept(this);
+        return this;
     }
 
     public AbstractElement clone() {

--- a/src/main/java/org/javawebstack/abstractdata/AbstractMapper.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractMapper.java
@@ -2,6 +2,9 @@ package org.javawebstack.abstractdata;
 
 import org.javawebstack.abstractdata.mapper.Mapper;
 
+/**
+ * @deprecated will be removed in the next release, replaced by org.javawebstack.abstractdata.mapper.Mapper
+ */
 @Deprecated
 public class AbstractMapper {
 

--- a/src/main/java/org/javawebstack/abstractdata/AbstractNull.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractNull.java
@@ -19,20 +19,22 @@ public class AbstractNull implements AbstractElement {
     }
 
     public String string(boolean strict) throws AbstractCoercingException {
-        if(strict)
-            throw new AbstractCoercingException(Type.STRING, Type.NULL);
         return null;
     }
 
     public Boolean bool(boolean strict) throws AbstractCoercingException {
-        if(strict)
-            throw new AbstractCoercingException(Type.STRING, Type.NULL);
         return null;
     }
 
     public Number number(boolean strict) throws AbstractCoercingException {
-        if(strict)
-            throw new AbstractCoercingException(Type.STRING, Type.NULL);
+        return null;
+    }
+
+    public AbstractObject object(boolean strict) throws AbstractCoercingException {
+        return null;
+    }
+
+    public AbstractArray array(boolean strict) throws AbstractCoercingException {
         return null;
     }
 

--- a/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
@@ -233,6 +233,12 @@ public class AbstractObject implements AbstractElement {
         return tree;
     }
 
+    public Map<String, Object> toTree(String keySeparator) {
+        Map<String, Object> tree = new HashMap<>();
+        toTree().forEach((k, v) -> tree.put(String.join(keySeparator, k), v));
+        return tree;
+    }
+
     public Set<String> keys() {
         return entries.keySet();
     }

--- a/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
+++ b/src/main/java/org/javawebstack/abstractdata/AbstractObject.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -237,6 +238,11 @@ public class AbstractObject implements AbstractElement {
         Map<String, Object> tree = new HashMap<>();
         toTree().forEach((k, v) -> tree.put(String.join(keySeparator, k), v));
         return tree;
+    }
+
+    public AbstractObject use(Consumer<AbstractObject> consumer) {
+        consumer.accept(this);
+        return this;
     }
 
     public Set<String> keys() {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
@@ -273,14 +273,14 @@ public final class DefaultMappers {
         public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
             try {
                 DateFormat df = context.getAnnotation(DateFormat.class);
-                java.text.DateFormat dateFormat = (df != null && df.value().length() > 0) ? new SimpleDateFormat(df.value()) : context.getMapper().getDateFormat();
                 Date date;
-                try {
+                if(df != null && df.epoch()) {
                     long time = element.number(context.getMapper().isStrict()).longValue();
-                    if(df != null && !df.millis())
+                    if(!df.millis())
                         time *= 1000;
                     date = new Date(time);
-                } catch (AbstractCoercingException ex) {
+                } else {
+                    java.text.DateFormat dateFormat = (df != null && df.value().length() > 0) ? new SimpleDateFormat(df.value()) : context.getMapper().getDateFormat();
                     date = dateFormat.parse(element.string(context.getMapper().isStrict()));
                 }
                 if(type.equals(Date.class))


### PR DESCRIPTION
- Disabled coercing errors for AbstractNull to replicate the previous behavior
- Fixed the DateMapper
- Added a toTree method that joins the key segments
- Added a "use" helper method to allow executing code in the chaining flow