### PR TITLE
Fixed malformed-number parsing (#31) and added java.time mapper support (#23)

### DIFF
--- a/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
+++ b/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
@@ -111,17 +111,29 @@ public class JsonParser {
 
     private AbstractPrimitive parseNumber(Deque<Character> stack) {
         StringBuilder sb = new StringBuilder();
-        while (stack.peek() != null && (Character.isDigit(stack.peek()) || stack.peek() == '.' || stack.peek() == '+' || stack.peek() == '-' || stack.peek() == 'E' || stack.peek() == 'e'))
-            sb.append(stack.pop());
-        String s = sb.toString();
-        if (s.contains(".")) {
-            return new AbstractPrimitive(Double.parseDouble(s));
-        } else {
-            long l = Long.parseLong(s);
-            if (l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE)
-                return new AbstractPrimitive((int) l);
-            return new AbstractPrimitive(l);
+        for (char c : stack) {
+            if (Character.isDigit(c) || c == '.' || c == '+' || c == '-' || c == 'E' || c == 'e')
+                sb.append(c);
+            else
+                break;
         }
+        String s = sb.toString();
+        AbstractPrimitive result;
+        try {
+            if (s.contains(".") || s.contains("e") || s.contains("E")) {
+                result = new AbstractPrimitive(Double.parseDouble(s));
+            } else {
+                long l = Long.parseLong(s);
+                result = l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE ? new AbstractPrimitive((int) l) : new AbstractPrimitive(l);
+            }
+        } catch (NumberFormatException e) {
+            // Not actually a valid number: leave the characters on the stack so the
+            // caller reports a proper ParseException at the offending position.
+            return null;
+        }
+        for (int i = 0; i < s.length(); i++)
+            stack.pop();
+        return result;
     }
 
     private AbstractPrimitive parseString(Deque<Character> stack) {

--- a/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
+++ b/src/main/java/org/javawebstack/abstractdata/json/JsonParser.java
@@ -118,22 +118,38 @@ public class JsonParser {
                 break;
         }
         String s = sb.toString();
-        AbstractPrimitive result;
-        try {
-            if (s.contains(".") || s.contains("e") || s.contains("E")) {
-                result = new AbstractPrimitive(Double.parseDouble(s));
-            } else {
-                long l = Long.parseLong(s);
-                result = l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE ? new AbstractPrimitive((int) l) : new AbstractPrimitive(l);
+        AbstractPrimitive result = toNumber(s);
+        if (result == null) {
+            // Malformed token (e.g. "1.2.3", "12e"): consume the longest valid numeric prefix
+            // so the caller reports the ParseException at the offending character instead of the
+            // token start. The token is still rejected as a whole -- no partial number is accepted.
+            int valid = 0;
+            for (int i = s.length() - 1; i > 0; i--) {
+                if (toNumber(s.substring(0, i)) != null) {
+                    valid = i;
+                    break;
+                }
             }
-        } catch (NumberFormatException e) {
-            // Not actually a valid number: leave the characters on the stack so the
-            // caller reports a proper ParseException at the offending position.
+            for (int i = 0; i < valid; i++)
+                stack.pop();
             return null;
         }
         for (int i = 0; i < s.length(); i++)
             stack.pop();
         return result;
+    }
+
+    private AbstractPrimitive toNumber(String s) {
+        if (s.isEmpty())
+            return null;
+        try {
+            if (s.contains(".") || s.contains("e") || s.contains("E"))
+                return new AbstractPrimitive(Double.parseDouble(s));
+            long l = Long.parseLong(s);
+            return l >= Integer.MIN_VALUE && l <= Integer.MAX_VALUE ? new AbstractPrimitive((int) l) : new AbstractPrimitive(l);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private AbstractPrimitive parseString(Deque<Character> stack) {

--- a/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
@@ -336,6 +336,7 @@ public final class DefaultMappers {
 
         public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
             DateFormat df = context.getAnnotation(DateFormat.class);
+            String raw = element.isPrimitive() ? element.string() : element.toJsonString();
             try {
                 if (df != null && df.epoch()) {
                     if (!type.equals(Instant.class))
@@ -348,10 +349,12 @@ public final class DefaultMappers {
                     formatter = DateTimeFormatter.ofPattern(df.value());
                     if (df.timezone().length() > 0)
                         formatter = formatter.withZone(ZoneId.of(df.timezone()));
+                    else if (type.equals(Instant.class))
+                        formatter = formatter.withZone(ZoneOffset.UTC);
                 }
                 return parse(type, element.string(context.getMapper().isStrict()), formatter);
             } catch (DateTimeException | IllegalArgumentException | AbstractCoercingException ex) {
-                throw new MapperException("Failed to parse date '" + element.string() + "'" + (context.getField() != null ? " for field '" + context.getFieldName() + "'" : ""));
+                throw new MapperException("Failed to parse date '" + raw + "'" + (context.getField() != null ? " for field '" + context.getFieldName() + "'" : ""));
             }
         }
 

--- a/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
+++ b/src/main/java/org/javawebstack/abstractdata/mapper/DefaultMappers.java
@@ -12,6 +12,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
@@ -22,6 +25,7 @@ public final class DefaultMappers {
     public static final CollectionMapper COLLECTION = new CollectionMapper();
     public static final MapMapper MAP = new MapMapper();
     public static final DateMapper DATE = new DateMapper();
+    public static final JavaTimeMapper JAVA_TIME = new JavaTimeMapper();
     public static final AbstractMapper ABSTRACT = new AbstractMapper();
 
     public static final FallbackMapper FALLBACK = new FallbackMapper();
@@ -34,7 +38,8 @@ public final class DefaultMappers {
                 PRIMITIVE,
                 COLLECTION,
                 MAP,
-                DATE
+                DATE,
+                JAVA_TIME
         }) {
             for (Class<?> type : adapter.getSupportedTypes())
                 map.put(type, adapter);
@@ -293,6 +298,99 @@ public final class DefaultMappers {
                     Date.class,
                     Timestamp.class,
                     java.sql.Date.class
+            };
+        }
+
+    }
+
+    public static final class JavaTimeMapper implements MapperTypeAdapter {
+
+        private JavaTimeMapper() {
+        }
+
+        public AbstractElement toAbstract(MapperContext context, Object value) throws MapperException {
+            if (!(value instanceof TemporalAccessor))
+                return null;
+            DateFormat df = context.getAnnotation(DateFormat.class);
+            try {
+                if (df != null && df.epoch()) {
+                    if (!(value instanceof Instant))
+                        throw new MapperException("@DateFormat epoch mode is only supported for Instant, not '" + value.getClass().getName() + "'");
+                    Instant instant = (Instant) value;
+                    return new AbstractPrimitive(df.millis() ? instant.toEpochMilli() : instant.getEpochSecond());
+                }
+                if (df != null && df.value().length() > 0) {
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(df.value());
+                    if (df.timezone().length() > 0)
+                        formatter = formatter.withZone(ZoneId.of(df.timezone()));
+                    else if (value instanceof Instant)
+                        formatter = formatter.withZone(ZoneOffset.UTC);
+                    return new AbstractPrimitive(formatter.format((TemporalAccessor) value));
+                }
+                // Each supported type's toString() is its canonical ISO-8601 form and round-trips through its own parse().
+                return new AbstractPrimitive(value.toString());
+            } catch (DateTimeException | IllegalArgumentException ex) {
+                throw new MapperException("Failed to format date" + (context.getField() != null ? " for field '" + context.getFieldName() + "'" : "") + ": " + ex.getMessage());
+            }
+        }
+
+        public Object fromAbstract(MapperContext context, AbstractElement element, Class<?> type) throws MapperException {
+            DateFormat df = context.getAnnotation(DateFormat.class);
+            try {
+                if (df != null && df.epoch()) {
+                    if (!type.equals(Instant.class))
+                        throw new MapperException("@DateFormat epoch mode is only supported for Instant, not '" + type.getName() + "'");
+                    long time = element.number(context.getMapper().isStrict()).longValue();
+                    return df.millis() ? Instant.ofEpochMilli(time) : Instant.ofEpochSecond(time);
+                }
+                DateTimeFormatter formatter = null;
+                if (df != null && df.value().length() > 0) {
+                    formatter = DateTimeFormatter.ofPattern(df.value());
+                    if (df.timezone().length() > 0)
+                        formatter = formatter.withZone(ZoneId.of(df.timezone()));
+                }
+                return parse(type, element.string(context.getMapper().isStrict()), formatter);
+            } catch (DateTimeException | IllegalArgumentException | AbstractCoercingException ex) {
+                throw new MapperException("Failed to parse date '" + element.string() + "'" + (context.getField() != null ? " for field '" + context.getFieldName() + "'" : ""));
+            }
+        }
+
+        private Object parse(Class<?> type, String s, DateTimeFormatter formatter) throws MapperException {
+            if (type.equals(LocalDate.class))
+                return formatter == null ? LocalDate.parse(s) : LocalDate.parse(s, formatter);
+            if (type.equals(LocalDateTime.class))
+                return formatter == null ? LocalDateTime.parse(s) : LocalDateTime.parse(s, formatter);
+            if (type.equals(LocalTime.class))
+                return formatter == null ? LocalTime.parse(s) : LocalTime.parse(s, formatter);
+            if (type.equals(Instant.class))
+                return formatter == null ? Instant.parse(s) : formatter.parse(s, Instant::from);
+            if (type.equals(OffsetDateTime.class))
+                return formatter == null ? OffsetDateTime.parse(s) : OffsetDateTime.parse(s, formatter);
+            if (type.equals(ZonedDateTime.class))
+                return formatter == null ? ZonedDateTime.parse(s) : ZonedDateTime.parse(s, formatter);
+            if (type.equals(OffsetTime.class))
+                return formatter == null ? OffsetTime.parse(s) : OffsetTime.parse(s, formatter);
+            if (type.equals(Year.class))
+                return formatter == null ? Year.parse(s) : Year.parse(s, formatter);
+            if (type.equals(YearMonth.class))
+                return formatter == null ? YearMonth.parse(s) : YearMonth.parse(s, formatter);
+            if (type.equals(MonthDay.class))
+                return formatter == null ? MonthDay.parse(s) : MonthDay.parse(s, formatter);
+            throw new MapperException("Unsupported java.time type '" + type.getName() + "'");
+        }
+
+        public Class<?>[] getSupportedTypes() {
+            return new Class[]{
+                    LocalDate.class,
+                    LocalDateTime.class,
+                    LocalTime.class,
+                    Instant.class,
+                    OffsetDateTime.class,
+                    ZonedDateTime.class,
+                    OffsetTime.class,
+                    Year.class,
+                    YearMonth.class,
+                    MonthDay.class
             };
         }
 

--- a/src/test/java/org/javawebstack/abstractdata/json/JsonParserTest.java
+++ b/src/test/java/org/javawebstack/abstractdata/json/JsonParserTest.java
@@ -92,6 +92,29 @@ public class JsonParserTest {
     }
 
     @Test
+    public void testParseScientificNotation() {
+        AbstractElement e = assertDoesNotThrow(() -> new JsonParser().parse("1e3"));
+        assertTrue(e.isNumber());
+        assertEquals(1000.0, e.number());
+        e = assertDoesNotThrow(() -> new JsonParser().parse("2.5E-2"));
+        assertTrue(e.isNumber());
+        assertEquals(0.025, e.number());
+    }
+
+    @Test
+    public void testParseMalformedNumber() {
+        // See issue #31: malformed numbers must fail fast with a ParseException
+        // instead of leaking a NumberFormatException.
+        ParseException e = assertThrows(ParseException.class, () -> new JsonParser().parse("--"));
+        assertEquals("Unexpected character '-' at line 1 pos 1", e.getMessage());
+        assertThrows(ParseException.class, () -> new JsonParser().parse("-"));
+        assertThrows(ParseException.class, () -> new JsonParser().parse("1.2.3"));
+        assertThrows(ParseException.class, () -> new JsonParser().parse("12e"));
+        assertThrows(ParseException.class, () -> new JsonParser().parse("."));
+        assertThrows(ParseException.class, () -> new JsonParser().parse("[--]"));
+    }
+
+    @Test
     public void testParseStringEscapeSeq() {
         Map<String, String> escapes = new HashMap<>();
         escapes.put("\\\"", "\"");

--- a/src/test/java/org/javawebstack/abstractdata/json/JsonParserTest.java
+++ b/src/test/java/org/javawebstack/abstractdata/json/JsonParserTest.java
@@ -108,10 +108,16 @@ public class JsonParserTest {
         ParseException e = assertThrows(ParseException.class, () -> new JsonParser().parse("--"));
         assertEquals("Unexpected character '-' at line 1 pos 1", e.getMessage());
         assertThrows(ParseException.class, () -> new JsonParser().parse("-"));
-        assertThrows(ParseException.class, () -> new JsonParser().parse("1.2.3"));
-        assertThrows(ParseException.class, () -> new JsonParser().parse("12e"));
         assertThrows(ParseException.class, () -> new JsonParser().parse("."));
         assertThrows(ParseException.class, () -> new JsonParser().parse("[--]"));
+
+        // The error points at the offending character within the token, not the token start.
+        e = assertThrows(ParseException.class, () -> new JsonParser().parse("1.2.3"));
+        assertEquals("Unexpected character '.' at line 1 pos 4", e.getMessage());
+        assertEquals(3, e.getErrorOffset());
+        e = assertThrows(ParseException.class, () -> new JsonParser().parse("12e"));
+        assertEquals("Unexpected character 'e' at line 1 pos 3", e.getMessage());
+        assertEquals(2, e.getErrorOffset());
     }
 
     @Test

--- a/src/test/java/org/javawebstack/abstractdata/mapper/JavaTimeMapperTest.java
+++ b/src/test/java/org/javawebstack/abstractdata/mapper/JavaTimeMapperTest.java
@@ -92,4 +92,26 @@ public class JavaTimeMapperTest {
     public void testMalformedValueThrowsMapperException() {
         assertThrows(MapperException.class, () -> new Mapper().map(new org.javawebstack.abstractdata.AbstractPrimitive("not-a-date"), LocalDate.class));
     }
+
+    @Test
+    public void testNonPrimitiveValueThrowsMapperException() {
+        assertThrows(MapperException.class, () -> new Mapper().map(new org.javawebstack.abstractdata.AbstractObject(), LocalDate.class));
+    }
+
+    static class InstantPatternHolder {
+        @DateFormat("yyyy-MM-dd'T'HH:mm:ss")
+        Instant ts;
+    }
+
+    @Test
+    public void testCustomPatternInstantRoundTrip() {
+        InstantPatternHolder holder = new InstantPatternHolder();
+        holder.ts = Instant.parse("2026-06-09T13:50:45Z");
+
+        AbstractElement element = assertDoesNotThrow(() -> new Mapper().map(holder));
+        assertEquals("2026-06-09T13:50:45", element.object().get("ts").string());
+
+        InstantPatternHolder parsed = assertDoesNotThrow(() -> new Mapper().map(element, InstantPatternHolder.class));
+        assertEquals(holder.ts, parsed.ts);
+    }
 }

--- a/src/test/java/org/javawebstack/abstractdata/mapper/JavaTimeMapperTest.java
+++ b/src/test/java/org/javawebstack/abstractdata/mapper/JavaTimeMapperTest.java
@@ -1,0 +1,95 @@
+package org.javawebstack.abstractdata.mapper;
+
+import org.javawebstack.abstractdata.AbstractElement;
+import org.javawebstack.abstractdata.mapper.annotation.DateFormat;
+import org.javawebstack.abstractdata.mapper.exception.MapperException;
+import org.junit.jupiter.api.Test;
+
+import java.time.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JavaTimeMapperTest {
+
+    @Test
+    public void testIsoRoundTripTopLevel() {
+        assertRoundTrip(LocalDate.of(2026, 6, 9), LocalDate.class, "2026-06-09");
+        assertRoundTrip(LocalDateTime.of(2026, 6, 9, 15, 30, 45), LocalDateTime.class, "2026-06-09T15:30:45");
+        assertRoundTrip(LocalTime.of(15, 30, 45), LocalTime.class, "15:30:45");
+        assertRoundTrip(Instant.parse("2026-06-09T13:50:45Z"), Instant.class, "2026-06-09T13:50:45Z");
+        assertRoundTrip(OffsetDateTime.of(2026, 6, 9, 15, 30, 45, 0, ZoneOffset.ofHours(2)), OffsetDateTime.class, "2026-06-09T15:30:45+02:00");
+        assertRoundTrip(ZonedDateTime.of(2026, 6, 9, 15, 30, 45, 0, ZoneId.of("Europe/Berlin")), ZonedDateTime.class, "2026-06-09T15:30:45+02:00[Europe/Berlin]");
+        assertRoundTrip(OffsetTime.of(15, 30, 45, 0, ZoneOffset.ofHours(2)), OffsetTime.class, "15:30:45+02:00");
+        assertRoundTrip(Year.of(2026), Year.class, "2026");
+        assertRoundTrip(YearMonth.of(2026, 6), YearMonth.class, "2026-06");
+        assertRoundTrip(MonthDay.of(6, 9), MonthDay.class, "--06-09");
+    }
+
+    private <T> void assertRoundTrip(T value, Class<T> type, String expected) {
+        Mapper mapper = new Mapper();
+        AbstractElement element = assertDoesNotThrow(() -> mapper.map(value));
+        assertTrue(element.isString(), type.getSimpleName() + " should serialize to a string");
+        assertEquals(expected, element.string());
+        assertEquals(value, assertDoesNotThrow(() -> mapper.map(element, type)));
+    }
+
+    static class EpochHolder {
+        @DateFormat(epoch = true)
+        Instant seconds;
+        @DateFormat(epoch = true, millis = true)
+        Instant millis;
+    }
+
+    @Test
+    public void testEpochInstant() {
+        EpochHolder holder = new EpochHolder();
+        holder.seconds = Instant.ofEpochSecond(1781013045);
+        holder.millis = Instant.ofEpochMilli(1781013045123L);
+
+        AbstractElement element = assertDoesNotThrow(() -> new Mapper().map(holder));
+        assertEquals(1781013045L, element.object().get("seconds").number().longValue());
+        assertEquals(1781013045123L, element.object().get("millis").number().longValue());
+
+        EpochHolder parsed = assertDoesNotThrow(() -> new Mapper().map(element, EpochHolder.class));
+        assertEquals(Instant.ofEpochSecond(1781013045), parsed.seconds);
+        assertEquals(Instant.ofEpochMilli(1781013045123L), parsed.millis);
+    }
+
+    static class PatternHolder {
+        @DateFormat("dd.MM.yyyy")
+        LocalDate day;
+        @DateFormat("yyyy-MM-dd HH:mm:ss")
+        LocalDateTime moment;
+    }
+
+    @Test
+    public void testCustomPattern() {
+        PatternHolder holder = new PatternHolder();
+        holder.day = LocalDate.of(2026, 6, 9);
+        holder.moment = LocalDateTime.of(2026, 6, 9, 15, 30, 45);
+
+        AbstractElement element = assertDoesNotThrow(() -> new Mapper().map(holder));
+        assertEquals("09.06.2026", element.object().get("day").string());
+        assertEquals("2026-06-09 15:30:45", element.object().get("moment").string());
+
+        PatternHolder parsed = assertDoesNotThrow(() -> new Mapper().map(element, PatternHolder.class));
+        assertEquals(holder.day, parsed.day);
+        assertEquals(holder.moment, parsed.moment);
+    }
+
+    static class BadEpochHolder {
+        @DateFormat(epoch = true)
+        LocalDate day = LocalDate.of(2026, 6, 9);
+    }
+
+    @Test
+    public void testEpochRejectedForNonInstant() {
+        MapperException e = assertThrows(MapperException.class, () -> new Mapper().map(new BadEpochHolder()));
+        assertTrue(e.getMessage().contains("epoch"));
+    }
+
+    @Test
+    public void testMalformedValueThrowsMapperException() {
+        assertThrows(MapperException.class, () -> new Mapper().map(new org.javawebstack.abstractdata.AbstractPrimitive("not-a-date"), LocalDate.class));
+    }
+}


### PR DESCRIPTION
This PR bundles two independent changes.

## JSON parser: malformed numbers (#31)

`parseNumber` now validates the candidate token without consuming it and returns `null` on failure, so the existing error path reports a proper `ParseException` at the offending position instead of leaking a `NumberFormatException`. Exponent-only numbers (e.g. `1e3`), previously routed to `Long.parseLong` and failing, now parse as doubles.

## Mapper: java.time support (#23)

A new `JavaTimeMapper` (sibling of `DateMapper`, registered in `DefaultMappers`) maps the core `java.time` types: `LocalDate`, `LocalDateTime`, `LocalTime`, `Instant`, `OffsetDateTime`, `ZonedDateTime`, `OffsetTime`, `Year`, `YearMonth`, `MonthDay`. Values serialize to their canonical ISO-8601 form by default. The existing `@DateFormat` annotation still applies: a custom pattern uses `DateTimeFormatter` syntax, and epoch mode is supported for `Instant` only (any other type throws a `MapperException` rather than silently dropping the zone/offset). No public API or Java language level change (target stays 8).

Out of scope, as separate follow-ups: `Duration` / `Period` / `ZoneId` / `ZoneOffset`, and `java.time` support in the BSON converter.

## Test plan

- `mvn test` green.
- `JsonParserTest`: added malformed-number cases (`--`, `-`, `1.2.3`, `12e`, `.`) asserting `ParseException`, plus scientific notation (`1e3`, `2.5E-2`).
- `JavaTimeMapperTest`: ISO round-trip for all 10 types, epoch `Instant` (seconds/millis), custom pattern, epoch rejection on a non-`Instant` type, and malformed input -> `MapperException`.
